### PR TITLE
Fix compatibility issue with rack 2.3

### DIFF
--- a/lib/racksh/init.rb
+++ b/lib/racksh/init.rb
@@ -20,7 +20,7 @@ module Rack
       config_ru = ENV['CONFIG_RU']
 
       # build Rack app
-      rack_app = Rack::Builder.parse_file(config_ru).first
+      rack_app = Array(Rack::Builder.parse_file(config_ru)).first
       $rack = Rack::Shell::Session.new(rack_app)
 
       # run ~/.rackshrc


### PR DESCRIPTION
- Rack gem changed inplementation of Rack::Builder.load_file method in version 2.3 . It used to return array where first item was the rack app object.
- in new implementation the method returns directly the rack app. Here is a change: rack/rack@b95cb72#diff-79892c6315a7f9c02489803e95ce828a8a32759b9f8f196aa98e6826eb562e55L107
- to keep compatibility with older versions of rack we wrap the return value to Array()