### PR TITLE
Add license to gemspec

### DIFF
--- a/racksh.gemspec
+++ b/racksh.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.date = Date.today.to_s
   s.authors = ["Marcin Kulik"]
   s.email = %q{marcin.kulik@gmail.com}
+  s.license = 'MIT'
   s.has_rdoc = false
   s.homepage = %q{http://github.com/sickill/racksh}
   s.summary = %q{Console for any Rack based ruby web app}


### PR DESCRIPTION
Add [mit license](https://github.com/sickill/racksh/blob/65c35251a9c830fcc6f39fe03972897ebc110f88/LICENSE.txt) to Gemspec per [ruby specification](https://guides.rubygems.org/specification-reference/#license=). This makes it clear for anyone using this code of the license type. In addition, automated tools like [`license_finder`](https://github.com/pivotal/LicenseFinder) can now detect the license type for this gem.  This will now show the license type on the [racksh RubyGems page](https://rubygems.org/gems/racksh) as well.